### PR TITLE
Fix Element equatable implementation

### DIFF
--- a/Sources/TigaseSwift/xml/Element.swift
+++ b/Sources/TigaseSwift/xml/Element.swift
@@ -460,5 +460,8 @@ public func ==(lhs: Element, rhs: Element) -> Bool {
             return false;
         }
     }
+    if (lhs.nodes != rhs.nodes) {
+        return false;
+    }
     return true;
 }


### PR DESCRIPTION
If the number of nodes is the same the comparison returns true even if the content is not equal

Signed-off-by: Antonio Cabezuelo Vivo <antonio@tapsandswipes.com>