### PR TITLE
Make initializer in DefaultRosterStore public

### DIFF
--- a/Sources/Martin/modules/roster/DefaultRosterStore.swift
+++ b/Sources/Martin/modules/roster/DefaultRosterStore.swift
@@ -34,7 +34,9 @@ open class DefaultRosterStore: RosterStore {
     private var version: String?;
     
     private let dispatcher = DispatchQueue(label: "DefaultRoomStore");
-    
+
+    public init() {}
+
     public func clear(for context: Context) {
         return dispatcher.async {
             self.version = nil;


### PR DESCRIPTION
Unless I’m missing something, DefaultRosterStore cannot be instanciated when using the library because its implicit constructor is internal by default. I’m just adding a public constructor.